### PR TITLE
Add openid scope to example FastAPI app

### DIFF
--- a/veda-app-samples/fastapi-veda-auth/api/main.py
+++ b/veda-app-samples/fastapi-veda-auth/api/main.py
@@ -75,6 +75,7 @@ app = FastAPI(
         "appName": "ExampleApp",
         "clientId": settings.client_id,
         "usePkceWithAuthorizationCodeGrant": True,
+        "scopes": "openid",
     },
 )
 


### PR DESCRIPTION
This PR will ensure that the `openid` scope is requested when authenticating with VEDA Auth Central.  The appears to be required with our current implementation of VEDA Auth Central.

@lahirujayathilake 