### PR TITLE
Simplify example via OIDC configuration endpoint

### DIFF
--- a/veda-app-samples/fastapi-veda-auth/docker-compose.yaml
+++ b/veda-app-samples/fastapi-veda-auth/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - AUTH_PROVIDER_URL=https://api.veda.usecustos.org/api/v1/identity-management
-      - AUTH_PROVIDER_JWKS_URL=https://api.veda.usecustos.org/api/v1/identity-management/.well-known/jwks.json
+      - OIDC_CONFIG_URL=https://api.veda.usecustos.org/api/v1/identity-management/.well-known/openid-configuration?client_id=veda-iui65nmkgaf7bihdyndc-10000000
       - CLIENT_ID=veda-iui65nmkgaf7bihdyndc-10000000
     restart: unless-stopped


### PR DESCRIPTION
I've learned that FastAPI has a convenient integration with OIDC.  This will make the configuration of the API simpler as things like the authorization, token, and JWKS URLs, along with the available scopes, can be auto-configured based on the response from the OIDC configuration endpoint.