### PR TITLE
fix for 'no groups found' text

### DIFF
--- a/veda-auth-portal/src/components/Groups/index.tsx
+++ b/veda-auth-portal/src/components/Groups/index.tsx
@@ -122,7 +122,7 @@ export const Groups = () => {
             }
           </Tbody>
           {
-            ((!filteredGroups) || (!filteredGroups.data) || (filteredGroups.data?.groups?.length === 0)) && (
+            ((!filteredGroups) || (filteredGroups.length === 0)) && (
               <Tbody>
                 <Tr>
                   <Td colSpan={5} textAlign='center'>


### PR DESCRIPTION
'no groups found' should no longer show when you indeed have groups